### PR TITLE
Add configurable address and signer support

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -5834,6 +5834,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bech32 0.11.0",
+ "bs58 0.5.1",
  "bytes",
  "derive-new",
  "ed25519-dalek 2.1.1",

--- a/rust/main/chains/hyperlane-sovereign/Cargo.toml
+++ b/rust/main/chains/hyperlane-sovereign/Cargo.toml
@@ -29,6 +29,10 @@ hex.workspace = true
 num-traits.workspace = true
 
 ed25519-dalek = "2.1.1"
+bs58 = { version = "0.5.1", default-features = false, features = [
+  "std",
+  "alloc",
+] }
 sov-universal-wallet = { git = "https://@github.com/Sovereign-Labs/sovereign-sdk.git", branch = "nightly", features = [
   "serde",
 ] }

--- a/rust/main/chains/hyperlane-sovereign/src/application/mod.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/application/mod.rs
@@ -8,7 +8,7 @@ use hyperlane_operation_verifier::{
 };
 use hyperlane_warp_route::TokenMessage;
 
-use crate::signers::ed25519::SOV_HEX_ADDRESS_LEADING_ZEROS;
+use crate::signers::sovereign::SOV_HEX_ADDRESS_LEADING_ZEROS;
 
 const WARP_ROUTE_MARKER: &str = "/";
 

--- a/rust/main/chains/hyperlane-sovereign/src/provider.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider.rs
@@ -5,13 +5,11 @@ use hyperlane_core::{
     BlockInfo, ChainCommunicationError, ChainInfo, ChainResult, HyperlaneChain, HyperlaneDomain,
     HyperlaneProvider, TxnInfo, H256, H512, U256,
 };
-use tracing::info;
 
 mod client;
 mod methods;
 mod transaction;
 
-use crate::signers::Crypto;
 use crate::{ConnectionConf, Signer};
 pub use client::SovereignClient;
 
@@ -77,32 +75,7 @@ impl HyperlaneProvider for SovereignProvider {
     }
 
     async fn get_balance(&self, address: String) -> ChainResult<U256> {
-        let signer = &self.client.signer;
-
-        match self.client.get_balance(&address).await {
-            // This error means that the rollup couldn't parse valid bech32 address
-            // from the provided one. This usually happens in case relayer or validator
-            // wants to check its own balance using ethereum styled address (returned by default by signer),
-            // but rollup uses ed25519 based crypto scheme rather than ethereum one.
-            // We can easily fix that case and re-request balance using bech32 address
-            Err(ChainCommunicationError::CustomError(reason))
-                if reason.contains("Bech32 error")
-                    && signer
-                        .ethereum()
-                        .address()
-                        .is_ok_and(|addr| addr == address) =>
-            {
-                let bech32_addr = signer.ed25519().address()?;
-
-                info!(
-                    address = bech32_addr,
-                    "Re-requesting balance using bech32 address"
-                );
-                self.client.get_balance(bech32_addr).await
-            }
-
-            res => res,
-        }
+        self.client.get_balance(&address).await
     }
 
     /// Sovereign sdk uses multidimensional gas price, so we have to return `None` for

--- a/rust/main/chains/hyperlane-sovereign/src/provider/transaction.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider/transaction.rs
@@ -5,7 +5,7 @@ use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use futures::stream::BoxStream;
 use futures::StreamExt;
-use hyperlane_core::{ChainCommunicationError, ChainResult, H256};
+use hyperlane_core::{ChainResult, H256};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use sov_universal_wallet::schema::RollupRoots;
@@ -24,22 +24,10 @@ impl SovereignClient {
     pub async fn build_and_submit(&self, call_message: Value) -> ChainResult<(H256, String)> {
         let utx = self.build_tx_json(&call_message);
 
-        let tx = self.sign_tx(utx.clone(), self.signer.ed25519()).await?;
-        let body = match self.serialize_tx(&tx).await {
-            // if serialization failed with this error, it means that rollup uses an ethereum
-            // signing scheme. This is very ugly but currently there is no better way than try
-            // and fail
-            Err(ChainCommunicationError::CustomError(reason))
-                if reason.contains("Expected an array of size 33, but only found 32") =>
-            {
-                let tx = self.sign_tx(utx, self.signer.ethereum()).await?;
-                self.serialize_tx(&tx).await?
-            }
-
-            res => res?,
-        };
-
+        let tx = self.sign_tx(utx.clone(), &self.signer).await?;
+        let body = self.serialize_tx(&tx).await?;
         let hash = self.submit_tx(body.clone()).await?;
+
         self.wait_for_tx(hash).await?;
 
         Ok((hash, body))

--- a/rust/main/chains/hyperlane-sovereign/src/signers.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/signers.rs
@@ -17,15 +17,18 @@
 //! to choose the correct implementation during the runtime, however it's not available yet, and
 //! not planned for a foreseeable future.
 
+use std::sync::Arc;
+
 use hyperlane_core::{ChainResult, H256};
 
 pub mod ed25519;
 pub mod ethereum;
+pub mod sovereign;
 
 /// Common methods for signers
-pub trait Crypto {
+pub trait Crypto: std::fmt::Debug {
     /// Sign provided message and return signature's bytes
-    fn sign(&self, bytes: impl AsRef<[u8]>) -> ChainResult<Vec<u8>>;
+    fn sign(&self, bytes: &[u8]) -> ChainResult<Vec<u8>>;
 
     /// Get public key bytes
     fn public_key(&self) -> Vec<u8>;
@@ -40,28 +43,46 @@ pub trait Crypto {
 /// Signer for Sovereign chain.
 #[derive(Clone, Debug)]
 pub struct Signer {
-    /// ethereum crypto implementation
-    ethereum: ethereum::Signer,
-    /// ed25519 crypto implementation
-    ed25519: ed25519::Signer,
+    inner: Arc<dyn Crypto + Send + Sync>,
 }
 
 impl Signer {
     /// Create a new Sovereign signer.
-    pub fn new(private_key: &H256) -> ChainResult<Self> {
-        Ok(Signer {
-            ethereum: ethereum::Signer::new(private_key)?,
-            ed25519: ed25519::Signer::new(private_key)?,
-        })
+    pub fn new(private_key: &H256, account_type: &str, hrp: Option<String>) -> ChainResult<Self> {
+        let inner: Arc<dyn Crypto + Send + Sync> = match account_type {
+            "solana" => Arc::new(ed25519::Signer::new(private_key)?),
+            "ethereum" => Arc::new(ethereum::Signer::new(private_key)?),
+            "sovereign" => Arc::new(sovereign::Signer::new(
+                private_key,
+                hrp.ok_or(custom_err!(
+                    "HRP must be supplied for 'sovereign' accountTypes"
+                ))?,
+            )?),
+            _ => {
+                return Err(custom_err!(
+                    "Invalid account type: {}, valid values: 'solana' | 'ethereum' | 'sovereign'",
+                    account_type
+                ))
+            }
+        };
+        Ok(Self { inner })
+    }
+}
+
+impl Crypto for Signer {
+    fn sign(&self, bytes: &[u8]) -> ChainResult<Vec<u8>> {
+        self.inner.sign(bytes)
     }
 
-    /// An ethereum based signer
-    pub fn ethereum(&self) -> &impl Crypto {
-        &self.ethereum
+    fn public_key(&self) -> Vec<u8> {
+        self.inner.public_key()
     }
 
-    /// An edward based signer
-    pub fn ed25519(&self) -> &impl Crypto {
-        &self.ed25519
+    fn address(&self) -> ChainResult<String> {
+        self.inner.address()
+    }
+
+    fn h256_address(&self) -> H256 {
+        self.inner.h256_address()
     }
 }

--- a/rust/main/chains/hyperlane-sovereign/src/signers/ed25519.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/signers/ed25519.rs
@@ -1,15 +1,7 @@
-//! Ed25519 based crypto scheme used in sovereign. This is the default one used e.g. in `TestSpec`.
-
-use bech32::{Bech32m, Hrp};
 use ed25519_dalek::{Signer as _, SigningKey};
-use hyperlane_core::{ChainCommunicationError, ChainResult, H256};
+use hyperlane_core::{ChainResult, H256};
 
 use crate::signers::Crypto;
-
-/// Length of the sovereign address in bytes
-pub const SOV_ADDRESS_LENGTH: usize = 28;
-/// Amount of leading zeros padding in hex address representation.
-pub const SOV_HEX_ADDRESS_LEADING_ZEROS: usize = 4;
 
 /// Signer for Sovereign chain.
 #[derive(Clone, Debug)]
@@ -24,7 +16,7 @@ impl Signer {
 }
 
 impl Crypto for Signer {
-    fn sign(&self, bytes: impl AsRef<[u8]>) -> ChainResult<Vec<u8>> {
+    fn sign(&self, bytes: &[u8]) -> ChainResult<Vec<u8>> {
         Ok(self.0.sign(bytes.as_ref()).to_bytes().to_vec())
     }
 
@@ -33,51 +25,10 @@ impl Crypto for Signer {
     }
 
     fn address(&self) -> ChainResult<String> {
-        // Sov address uses first 28 bytes of the public key
-        // <https://github.com/Sovereign-Labs/sovereign-sdk-wip/blob/fdad6aef490656ce4ad6c93f486569acb71d11eb/crates/module-system/sov-modules-api/src/common/address.rs#L411-L415>
-        // <https://github.com/Sovereign-Labs/sovereign-sdk-wip/blob/fdad6aef490656ce4ad6c93f486569acb71d11eb/crates/module-system/sov-modules-api/src/common/address.rs#L365-L369>
-        let hrp = Hrp::parse("sov").expect("valid hrp");
-        let address = bech32::encode::<Bech32m>(
-            hrp,
-            &self.0.verifying_key().as_bytes()[..SOV_ADDRESS_LENGTH],
-        )
-        .map_err(|e| {
-            ChainCommunicationError::CustomError(format!(
-                "Encoding public key to bech32 failed: {e}"
-            ))
-        })?;
-
-        Ok(address)
+        Ok(bs58::encode(self.0.verifying_key().as_bytes()).into_string())
     }
 
     fn h256_address(&self) -> H256 {
-        let mut h256 = H256::zero();
-        h256[SOV_HEX_ADDRESS_LEADING_ZEROS..]
-            .copy_from_slice(&self.0.verifying_key().to_bytes()[..SOV_ADDRESS_LENGTH]);
-        h256
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_address_from_h256() {
-        // values from <https://github.com/Sovereign-Labs/sov-rollup-starter-wip/blob/94ce661edb1dcc338bc4b7232b8fe8632e7540c5/test-data/keys/token_deployer_private_key.json>
-        let private_key = H256([
-            117, 251, 248, 217, 135, 70, 194, 105, 46, 80, 41, 66, 185, 56, 200, 35, 121, 253, 9,
-            234, 159, 91, 96, 212, 211, 158, 135, 225, 180, 36, 104, 253,
-        ]);
-        let signer = Signer::new(&private_key).unwrap();
-
-        assert_eq!(
-            "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
-            signer.address().unwrap()
-        );
-        assert_eq!(
-            "0x00000000f8ad2437a279e1c8932c07358c91dc4fe34864a98c6c25f298e2a019",
-            format!("{:?}", signer.h256_address()),
-        );
+        H256::from_slice(self.0.verifying_key().as_bytes())
     }
 }

--- a/rust/main/chains/hyperlane-sovereign/src/signers/ethereum.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/signers/ethereum.rs
@@ -37,7 +37,7 @@ impl Signer {
 }
 
 impl Crypto for Signer {
-    fn sign(&self, bytes: impl AsRef<[u8]>) -> ChainResult<Vec<u8>> {
+    fn sign(&self, bytes: &[u8]) -> ChainResult<Vec<u8>> {
         let digest = Keccak256::new_with_prefix(bytes.as_ref());
 
         self.0

--- a/rust/main/chains/hyperlane-sovereign/src/signers/sovereign.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/signers/sovereign.rs
@@ -1,0 +1,89 @@
+//! Ed25519 based crypto scheme used in sovereign. This is the default one used e.g. in `TestSpec`.
+
+use bech32::{Bech32m, Hrp};
+use ed25519_dalek::{Signer as _, SigningKey};
+use hyperlane_core::{ChainCommunicationError, ChainResult, H256};
+
+use crate::signers::Crypto;
+
+/// Length of the sovereign address in bytes
+pub const SOV_ADDRESS_LENGTH: usize = 28;
+/// Amount of leading zeros padding in hex address representation.
+pub const SOV_HEX_ADDRESS_LEADING_ZEROS: usize = 4;
+
+/// Signer for Sovereign chain.
+#[derive(Clone, Debug)]
+pub struct Signer {
+    key: SigningKey,
+    hrp: String,
+}
+
+impl Signer {
+    /// Create a new Sovereign ed25519 signer.
+    pub fn new(private_key: &H256, hrp: String) -> ChainResult<Self> {
+        let private_key = private_key.as_fixed_bytes().into();
+        Ok(Signer {
+            key: private_key,
+            hrp,
+        })
+    }
+}
+
+impl Crypto for Signer {
+    fn sign(&self, bytes: &[u8]) -> ChainResult<Vec<u8>> {
+        Ok(self.key.sign(bytes.as_ref()).to_bytes().to_vec())
+    }
+
+    fn public_key(&self) -> Vec<u8> {
+        self.key.verifying_key().as_bytes().to_vec()
+    }
+
+    fn address(&self) -> ChainResult<String> {
+        // Sov address uses first 28 bytes of the public key
+        // <https://github.com/Sovereign-Labs/sovereign-sdk-wip/blob/fdad6aef490656ce4ad6c93f486569acb71d11eb/crates/module-system/sov-modules-api/src/common/address.rs#L411-L415>
+        // <https://github.com/Sovereign-Labs/sovereign-sdk-wip/blob/fdad6aef490656ce4ad6c93f486569acb71d11eb/crates/module-system/sov-modules-api/src/common/address.rs#L365-L369>
+        let hrp = Hrp::parse(&self.hrp).expect("valid hrp");
+        let address = bech32::encode::<Bech32m>(
+            hrp,
+            &self.key.verifying_key().as_bytes()[..SOV_ADDRESS_LENGTH],
+        )
+        .map_err(|e| {
+            ChainCommunicationError::CustomError(format!(
+                "Encoding public key to bech32 failed: {e}"
+            ))
+        })?;
+
+        Ok(address)
+    }
+
+    fn h256_address(&self) -> H256 {
+        let mut h256 = H256::zero();
+        h256[SOV_HEX_ADDRESS_LEADING_ZEROS..]
+            .copy_from_slice(&self.key.verifying_key().to_bytes()[..SOV_ADDRESS_LENGTH]);
+        h256
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_address_from_h256() {
+        // values from <https://github.com/Sovereign-Labs/sov-rollup-starter-wip/blob/94ce661edb1dcc338bc4b7232b8fe8632e7540c5/test-data/keys/token_deployer_private_key.json>
+        let private_key = H256([
+            117, 251, 248, 217, 135, 70, 194, 105, 46, 80, 41, 66, 185, 56, 200, 35, 121, 253, 9,
+            234, 159, 91, 96, 212, 211, 158, 135, 225, 180, 36, 104, 253,
+        ]);
+        let signer = Signer::new(&private_key, "sov".to_string()).unwrap();
+
+        assert_eq!(
+            "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
+            signer.address().unwrap()
+        );
+        assert_eq!(
+            "0x00000000f8ad2437a279e1c8932c07358c91dc4fe34864a98c6c25f298e2a019",
+            format!("{:?}", signer.h256_address()),
+        );
+    }
+}

--- a/rust/main/hyperlane-base/src/settings/parser/mod.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/mod.rs
@@ -427,6 +427,33 @@ fn parse_signer(signer: ValueParser) -> ConfigResult<SignerConf> {
                 is_legacy,
             })
         }};
+        (sovereignKey) => {{
+            let key = signer
+                .chain(&mut err)
+                .get_key("key")
+                .parse_private_key()
+                .unwrap_or_default();
+            let account_type = signer
+                .chain(&mut err)
+                .get_key("accountType")
+                .parse_string()
+                .unwrap_or("ethereum");
+            let parsed_hrp = signer
+                .chain(&mut err)
+                .get_opt_key("hrp")
+                .parse_string()
+                .unwrap_or_default();
+            let hrp = if parsed_hrp.is_empty() {
+                None
+            } else {
+                Some(parsed_hrp.to_owned())
+            };
+            err.into_result(SignerConf::SovereignKey {
+                key,
+                account_type: account_type.to_string(),
+                hrp,
+            })
+        }};
     }
 
     match signer_type {
@@ -434,6 +461,7 @@ fn parse_signer(signer: ValueParser) -> ConfigResult<SignerConf> {
         Some("aws") => parse_signer!(aws),
         Some("cosmosKey") => parse_signer!(cosmosKey),
         Some("starkKey") => parse_signer!(starkKey),
+        Some("sovereignKey") => parse_signer!(sovereignKey),
         Some(t) => {
             Err(eyre!("Unknown signer type `{t}`")).into_config_result(|| &signer.cwp + "type")
         }

--- a/rust/main/hyperlane-base/src/settings/signers.rs
+++ b/rust/main/hyperlane-base/src/settings/signers.rs
@@ -281,14 +281,9 @@ impl BuildableWithSignerConf for hyperlane_sovereign::Signer {
     }
 }
 
-/// We cannot determine if we should use ethereum or ed25519 crypto
-/// impl at this level, so we choose to use an ethereum one, because
-/// it is the one used in sov-rollup-starter
-///
-/// see [`hyperlane_sovereign::signers`] for more info
 impl ChainSigner for hyperlane_sovereign::Signer {
     fn address_string(&self) -> String {
-        self.address().expect("ethereum address cannot fail")
+        self.address().expect("address calculation cannot fail")
     }
     fn address_h256(&self) -> H256 {
         self.h256_address()

--- a/rust/main/rust-toolchain.toml
+++ b/rust/main/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85"
+channel = "1.81.0"
 profile = "default"


### PR DESCRIPTION
### Description

Makes addresses and signers configurable for sovereign. The "sovereign" signer is untested and I ahven't really looked much into it - its a copy+pasta, the high priority right now is getting agents working for zeta again

In the future it would be better to use the rollup schema to do most of this but this works for now.